### PR TITLE
use snippet from .snippet file

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,11 +12,8 @@ jobs:
 
       matrix:
         ruby:
-          - 2.3.3
           - 2.7.0
         include:
-          - ruby: 2.3.3
-            runner: ubuntu-16.04
           - ruby: 2.7.0
             runner: ubuntu-latest
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,9 +12,9 @@ jobs:
 
       matrix:
         ruby:
-          - 2.7.0
+          - 2.7.1
         include:
-          - ruby: 2.7.0
+          - ruby: 2.7.1
             runner: ubuntu-latest
 
     steps:

--- a/green_day.gemspec
+++ b/green_day.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/lib/green_day/snippet_builder.rb
+++ b/lib/green_day/snippet_builder.rb
@@ -7,8 +7,8 @@ module SnippetBuilder
   module_function
 
   def build
-    constants
-      .map { |snippet| '# ' + eval(snippet.to_s) }
+    [ARRAY_INPUT_SNIPPET, MULTIPLE_LINE_INPUT_SNIPPET]
+      .map { |snippet| '# ' + snippet }
       .join("\n") + "\n"
   end
 end

--- a/lib/green_day/snippet_builder.rb
+++ b/lib/green_day/snippet_builder.rb
@@ -7,8 +7,29 @@ module SnippetBuilder
   module_function
 
   def build
-    [ARRAY_INPUT_SNIPPET, MULTIPLE_LINE_INPUT_SNIPPET]
-      .map { |snippet| '# ' + snippet }
-      .join("\n") + "\n"
+    create_snippet_file unless File.exist?('.snippet')
+    read_snippet_file
   end
+
+  def create_snippet_file
+    file = File.open('.snippet', 'w')
+    constants
+      .map { |snippet| file.puts('# ' + eval(snippet.to_s)) }
+    file.close
+
+    # \e[32m green color
+    puts "    \e[32mcreate\e[0m #{FileUtils.pwd}/.snippet"
+
+    File.exist?('.snippet') ? true : false
+  end
+
+  def read_snippet_file
+    file = File.open('.snippet', 'r')
+    snippet = file.read || ''
+    file.close
+
+    snippet
+  end
+
+  private_class_method :create_snippet_file, :read_snippet_file
 end

--- a/lib/green_day/snippet_builder.rb
+++ b/lib/green_day/snippet_builder.rb
@@ -13,8 +13,8 @@ module SnippetBuilder
 
   def create_snippet_file
     file = File.open('.snippet', 'w')
-    constants
-      .map { |snippet| file.puts('# ' + eval(snippet.to_s)) }
+    [ARRAY_INPUT_SNIPPET, MULTIPLE_LINE_INPUT_SNIPPET]
+      .map { |snippet| file.puts("# #{snippet}") }
     file.close
 
     # \e[32m green color

--- a/lib/green_day/snippet_builder.rb
+++ b/lib/green_day/snippet_builder.rb
@@ -7,24 +7,22 @@ module SnippetBuilder
   module_function
 
   def build
-    create_snippet_file unless File.exist?('.snippet')
+    create_snippet_file unless File.exist?('.greenday_snippet')
     read_snippet_file
   end
 
   def create_snippet_file
-    file = File.open('.snippet', 'w')
+    file = File.open('.greenday_snippet', 'w')
     [ARRAY_INPUT_SNIPPET, MULTIPLE_LINE_INPUT_SNIPPET]
       .map { |snippet| file.puts("# #{snippet}") }
     file.close
 
     # \e[32m green color
-    puts "    \e[32mcreate\e[0m #{FileUtils.pwd}/.snippet"
-
-    File.exist?('.snippet') ? true : false
+    puts "    \e[32mcreate\e[0m .greenday_snippet"
   end
 
   def read_snippet_file
-    file = File.open('.snippet', 'r')
+    file = File.open('.greenday_snippet', 'r')
     snippet = file.read || ''
     file.close
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 RSpec.describe GreenDay::Cli do
   let!(:cli) { described_class.new }
 
+  RSpec.configure do |config|
+    config.after(:suite) do
+      FileUtils.remove_entry_secure('.snippet')
+    end
+  end
+
   describe 'new [contest name]' do
     # https://atcoder.jp/contests/abc150
     subject { cli.new('abc150') }

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe GreenDay::Cli do
       expect(File.exist?('abc150/spec/F_spec.rb')).to be_truthy
     end
 
+    it 'write snippet code' do
+      expect(File.read('abc150/A.rb')).to eq(
+        <<~SNIPPET
+          # n = gets.split.map(&:to_i)
+          # array = readlines.map(&:chomp!).map { |e| e.split.map(&:to_i) }
+        SNIPPET
+      )
+    end
+
     it 'write spec code' do
       expect(File.read('abc150/spec/A_spec.rb')).to eq(
         <<~SPEC

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -37,15 +37,6 @@ RSpec.describe GreenDay::Cli do
       expect(File.exist?('abc150/spec/F_spec.rb')).to be_truthy
     end
 
-    it 'write snippet code' do
-      expect(File.read('abc150/A.rb')).to eq(
-        <<~SNIPPET
-          # array = readlines.map(&:chomp!).map { |e| e.split.map(&:to_i) }
-          # n = gets.split.map(&:to_i)
-        SNIPPET
-      )
-    end
-
     it 'write spec code' do
       expect(File.read('abc150/spec/A_spec.rb')).to eq(
         <<~SPEC

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,21 +5,17 @@ require 'spec_helper'
 RSpec.describe GreenDay::Cli do
   let!(:cli) { described_class.new }
 
-  RSpec.configure do |config|
-    config.after(:suite) do
-      FileUtils.remove_entry_secure('.snippet')
-    end
-  end
-
   describe 'new [contest name]' do
     # https://atcoder.jp/contests/abc150
     subject { cli.new('abc150') }
-
+    snippet_file_exist = File.exist?('.greenday_snippet')
+    
     before :example do
       subject
     end
-
+    
     after :example do
+      FileUtils.remove_entry_secure('.greenday_snippet')
       FileUtils.remove_entry_secure('abc150')
     end
 
@@ -82,6 +78,16 @@ RSpec.describe GreenDay::Cli do
           end
         SPEC
       )
+    end
+
+    it 'create snippet file' , current: true do
+      expect(snippet_file_exist).not_to eq File.exist?('.greenday_snippet')
+    end
+
+    it 'uncreate snippet file when already exist' do
+    end
+
+    it 'apply modified snippet' do
     end
   end
 


### PR DESCRIPTION
### forkを用いた開発では自分のmasterにはPR作らないのが正しいかも

------------------------------------

# What
.snippetファイルを読み取ってスニペットにする仕様に変更した。
green_day newコマンド実行時、.snippetファイルがなければ生成するようにした。

# Why
ユーザが任意のスニペットを定義できるようにするため

# Tasks

- [x] 実装
- [x] テストグリーン
- [ ] versionの変更
- [ ] Rubocop通過
- [ ] CIグリーン


